### PR TITLE
RibThreads: Fix regression in FreeCAD 1.1 related to TwoLengths

### DIFF
--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -353,7 +353,7 @@ def make_rib_threads(body, hole, global_template: bool, rib_param: RibParameters
     pocket_entrance.Profile = (sketch_entrance, "")
     pocket_entrance.ReferenceAxis = (sketch_entrance, ["N_Axis"])
     pocket_entrance.Reversed = hole.Reversed
-    pocket_entrance.Type = "TwoLengths"
+    Utils.set_pocket_two_lengths(pocket_entrance)
     pocket_entrance.TaperAngle = "-20 deg"
     sketch_entrance.Visibility = False
     # 2.8 is roughly the tan(90 - 20 deg), so the taper will be complete

--- a/ffDesign_Utils.py
+++ b/ffDesign_Utils.py
@@ -339,6 +339,18 @@ def undo_shapebinder_is_safe() -> bool:
     return check_freecad_version(min_version=[1, 1, 0])
 
 
+def set_pocket_two_lengths(pocket):
+    try:
+        # In more recent versions, a two-length pocket is created using `SideType`
+        # See https://github.com/FreeCAD/FreeCAD/pull/21794
+        pocket.SideType = "Two sides"
+        pocket.Type = "Length"
+        pocket.Type2 = "Length"
+    except AttributeError:
+        # Legacy code for FreeCAD 1.0 and early 1.1 development builds
+        pocket.Type = "TwoLengths"
+
+
 class ffDesignAboutCommand:
     def GetResources(self):
         return {


### PR DESCRIPTION
In FreeCAD 1.1, the method for creating a two-sided pocket was changed. Instead of settings `Type = "TwoLengths"` you now have to set `SideType = "Two sides"`.

Update the RibThreads command to transparently use the correct method based on the presence of the `SideType` property.  This allows the addon to work on any version of FreeCAD correctly.  The changed behavior was tested against FreeCAD 1.0, a development build before the introduction of `SideType` (1.1.0devR41671) and the latest development build including the new behavior (1.1.0devR14555).

Link: https://github.com/FreeCAD/FreeCAD/pull/21794