### PR TITLE
ZipTieChannels: Fix regression in FreeCAD 1.1 related to Midplane

### DIFF
--- a/ffDesign_Utils.py
+++ b/ffDesign_Utils.py
@@ -351,6 +351,16 @@ def set_pocket_two_lengths(pocket):
         pocket.Type = "TwoLengths"
 
 
+def set_pocket_symmetric(pocket):
+    try:
+        # In more recent versions, a symmetric pocket is created using `SideType`
+        # See https://github.com/FreeCAD/FreeCAD/pull/21794
+        pocket.SideType = "Symmetric"
+    except AttributeError:
+        # Legacy code for FreeCAD 1.0 and early 1.1 development builds
+        pocket.Midplane = True
+
+
 class ffDesignAboutCommand:
     def GetResources(self):
         return {

--- a/ffDesign_ZipTieChannels.py
+++ b/ffDesign_ZipTieChannels.py
@@ -114,7 +114,7 @@ def make_zip_tie_channel(body, original, template, settings, suffix: str, locati
 
     pocket = body.newObject("PartDesign::Pocket", original.Name + suffix)
     pocket.Profile = (binder, "")
-    pocket.Midplane = True
+    Utils.set_pocket_symmetric(pocket)
     binder.Visibility = False
     pocket.setExpression("Length", f"{settings.Name}.ChannelWidth")
     pocket.Label = original.Label + suffix


### PR DESCRIPTION
In FreeCAD 1.1, the method for creating a symmetric pocket was changed. Instead of setting `Midplane = True`, you now have to set `SideType = Symmetric`.

Update the ZipTieChannels command to transparently use the correct method based on the presence of the `SideType` property.  This allows the addon to work on any version of FreeCAD correctly.  The changed behavior was tested against FreeCAD 1.0, a development build before the introduction of `SideType` (1.1.0devR41671) and a development build including the new behavior (1.1.0devR14555).

Link: https://github.com/FreeCAD/FreeCAD/pull/21794