### PR TITLE
Fixes for rib thread creation

### DIFF
--- a/Resources/panels/ffDesign_RibThreads.ui
+++ b/Resources/panels/ffDesign_RibThreads.ui
@@ -104,6 +104,16 @@
       <string>Thread Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Core Drill Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="ThreadNormative"/>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -111,23 +121,16 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="ThreadNormative"/>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="MajorDiameter"/>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="1" colspan="2">
        <widget class="Gui::QuantitySpinBox" name="ThreadCore" native="true">
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
         </property>
         <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Core Drill Size</string>
         </property>
        </widget>
       </item>
@@ -146,6 +149,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>gui::quantityspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -397,7 +397,7 @@ class RibThreadsTaskPanel:
             self.form.RibEngagement.setProperty("rawValue", rib_param.rib_engagement)
             self.form.RibDiameter.setProperty("rawValue", rib_param.rib_diameter)
         except KeyError:  # No predefined parameters for this thread
-            self.form.ThreadCore.setProperty("rawValue", hole.Diameter)
+            self.form.ThreadCore.setProperty("value", hole.Diameter)
 
             if not self.hole.ThreadType.startswith("ISOMetric"):
                 raise Utils.ffDesignError(

--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -389,6 +389,8 @@ class RibThreadsTaskPanel:
         try:
             rib_param = RIB_PARAMETERS[self.hole.ThreadType][self.hole.ThreadSize]
 
+            self.normative_diameter = App.Units.Quantity(rib_param.normative, "mm")
+
             self.form.ThreadCore.setProperty("rawValue", rib_param.core_bore)
             self.form.ThreadCore.setEnabled(False)
 
@@ -399,11 +401,24 @@ class RibThreadsTaskPanel:
         except KeyError:  # No predefined parameters for this thread
             self.form.ThreadCore.setProperty("value", hole.Diameter)
 
-            if not self.hole.ThreadType.startswith("ISOMetric"):
+            if self.hole.ThreadType.startswith("ISOMetric"):
+                try:
+                    self.normative_diameter = App.Units.Quantity(float(self.hole.ThreadSize[1:].split("x", 1)[0]), "mm")
+                except Exception as e:
+                    raise Utils.ffDesignError(
+                        f"Cannot extract normative diameter for thread {self.hole.ThreadSize} of type "
+                        + f"{self.hole.ThreadType} at the moment. Please reach out to the {Utils.Log.addon} authors!"
+                        + f"\n\nError: {e}"
+                    )
+            else:
                 raise Utils.ffDesignError(
                     f"Cannot derive parameters for thread {self.hole.ThreadSize} of type {self.hole.ThreadType} at the "
                     + f"moment. Please reach out to the {Utils.Log.addon} authors!"
                 )
+
+        norm_mm = self.normative_diameter.getValueAs("mm").Value
+        self.form.MajorDiameter.setText(f"ø {norm_mm:.2f} mm")
+        self.form.MajorDiameter.setEnabled(False)
 
     def onUseGlobalTemplate(self):
         self.global_template = self.form.UseGlobalTemplate.checkState() == QtCore.Qt.CheckState.Checked
@@ -457,18 +472,9 @@ class RibThreadsTaskPanel:
                 rib_diameter=self.form.RibDiameter.property("rawValue"),
             )
         except KeyError:  # No predefined rib parameters for this thread type
-            # Pull the normative diameter from the thread size string
-            if self.hole.ThreadType.startswith("ISOMetric"):
-                normative_diameter = float(self.hole.ThreadSize[1:].split("x", 1)[0])
-            else:
-                raise Utils.ffDesignError(
-                    f"Cannot derive parameters for thread {self.hole.ThreadSize} of type {self.hole.ThreadType} at the "
-                    + f"moment. Please reach out to the {Utils.Log.addon} authors!"
-                )
-
             rib_param = RibParameters(
                 name=self.hole.ThreadSize,
-                normative=normative_diameter,
+                normative=self.normative_diameter.getValueAs("mm").Value,
                 core_bore=self.form.ThreadCore.property("rawValue"),
                 core_diameter=self.form.ThreadCore.property("rawValue"),
                 entrance_depth=self.form.EntranceDepth.property("rawValue"),

--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -533,6 +533,25 @@ class RibThreadsTaskPanel:
         if self.hole.Diameter > rib_param.normative:
             raise Utils.ffDesignError("Hole diameter exceeds normative thread diameter.  Something is way off...")
 
+        if rib_param.rib_engagement <= 0:
+            raise Utils.ffDesignError(
+                f"Rib engagement must be greater than zero (got {rib_param.rib_engagement:.2f} mm)"
+            )
+
+        min_rib_diameter = rib_param.rib_engagement * 2
+        if rib_param.rib_diameter < min_rib_diameter:
+            raise Utils.ffDesignError(
+                f"Rib diameter is too small! Expected at least {min_rib_diameter:.2f} mm, got {rib_param.rib_diameter:.2f} mm"
+            )
+
+        if rib_param.entrance_depth <= 0:
+            raise Utils.ffDesignError(
+                f"Entrance depth must be greated than zero (got {rib_param.entrance_depth:.2f} mm)"
+            )
+
+        if rib_param.outer_diameter < rib_param.normative:
+            raise Utils.ffDesignError("Outer diameter must be greater than normative thread diameter!")
+
         if self.hole.Diameter > (rib_param.normative - rib_param.rib_engagement * 2):
             Utils.warning_confirm_proceed("Drill diameter of Hole is too big for ribs - they will get cut off!")
 

--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -57,6 +57,44 @@ RIB_PARAMETERS["ISOMetricProfile"]["M6x1"] = RIB_PARAMETERS["ISOMetricProfile"][
 RIB_PARAMETERS["ISOMetricProfile"]["M8x1.25"] = RIB_PARAMETERS["ISOMetricProfile"]["M8"]
 
 
+UTS_DIAMETERS = {
+    "#0": "0.0600 in",
+    "#1": "0.0730 in",
+    "#2": "0.0860 in",
+    "#3": "0.0990 in",
+    "#4": "0.1120 in",
+    "#5": "0.1250 in",
+    "#6": "0.1380 in",
+    "#8": "0.1640 in",
+    "#10": "0.1900 in",
+    "#12": "0.2160 in",
+    "1/4": "0.2500 in",
+    "5/16": "0.3125 in",
+    "3/8": "0.3750 in",
+    "7/16": "0.4375 in",
+    "1/2": "0.5000 in",
+    "9/16": "0.5625 in",
+    "5/8": "0.6250 in",
+    "3/4": "0.7500 in",
+    "7/8": "0.8750 in",
+    "1": "1.0000 in",
+    "1 1/8": "1.1250 in",
+    "1 1/4": "1.2500 in",
+    "1 3/8": "1.3750 in",
+    "1 1/2": "1.5000 in",
+    "1 3/4": "1.7500 in",
+    "2": "2.0000 in",
+    "2 1/4": "2.2500 in",
+    "2 1/2": "2.5000 in",
+    "2 3/4": "2.7500 in",
+    "3": "3.0000 in",
+    "3 1/4": "3.2500 in",
+    "3 1/2": "3.5000 in",
+    "3 3/4": "3.7500 in",
+    "4": "4.0000 in",
+}
+
+
 def make_parametric_circle(sketch, hole_loc: Utils.LocationExprSet, size_expr: str):
     Utils.assert_sketch(sketch)
 
@@ -409,6 +447,14 @@ class RibThreadsTaskPanel:
                         f"Cannot extract normative diameter for thread {self.hole.ThreadSize} of type "
                         + f"{self.hole.ThreadType} at the moment. Please reach out to the {Utils.Log.addon} authors!"
                         + f"\n\nError: {e}"
+                    )
+            elif self.hole.ThreadType in ("UNC", "UNF", "UNEF"):
+                try:
+                    self.normative_diameter = App.Units.Quantity(UTS_DIAMETERS[self.hole.ThreadSize])
+                except KeyError:
+                    raise Utils.ffDesignError(
+                        f"Cannot extract normative diameter for thread {self.hole.ThreadSize} of type "
+                        + f"{self.hole.ThreadType} at the moment. Please reach out to the {Utils.Log.addon} authors!"
                     )
             else:
                 raise Utils.ffDesignError(


### PR DESCRIPTION
As discovered in #44, the UX with non-metric threads is currently very bad.  This is mainly due to us not having any parameter presets for these thread types.

As a first step, at least fix all the errors that prevent you from entering your own rib thread parameters for UTS threads (UNC, UNF, UNEF).

Additionally, a lot more parameter checks are introduced to give the user hints about invalid parameter combinations.