### PR TITLE
Expose rotation/direction of teardrops and roof bridges in the respective task panels

### DIFF
--- a/Resources/panels/ffDesign_RoofBridge.ui
+++ b/Resources/panels/ffDesign_RoofBridge.ui
@@ -68,6 +68,23 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Rotation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="Gui::QuantitySpinBox" name="BridgeRotation" native="true">
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+     <property name="toolTip">
+      <string>Direction of the roof bridge around the hole axis.</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/Resources/panels/ffDesign_RoofBridge.ui
+++ b/Resources/panels/ffDesign_RoofBridge.ui
@@ -14,26 +14,6 @@
    <string>Roof Bridge</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Bridge Clearance</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="Gui::QuantitySpinBox" name="BridgeClearance" native="true">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-     <property name="minimum" stdset="0">
-      <double>0.000000000000000</double>
-     </property>
-     <property name="toolTip">
-      <string>Amount of additional clearance to add beneath the bridge to account for filament drooping.</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QCheckBox" name="DoCounterbore">
      <property name="toolTip">
@@ -54,6 +34,13 @@
     </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QRadioButton" name="Angle60">
+     <property name="text">
+      <string>60° Overhang Angle</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QRadioButton" name="Angle45">
      <property name="text">
@@ -61,10 +48,23 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QRadioButton" name="Angle60">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>60° Overhang Angle</string>
+      <string>Bridge Clearance</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="Gui::QuantitySpinBox" name="BridgeClearance" native="true">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+     <property name="minimum" stdset="0">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="toolTip">
+      <string>Amount of additional clearance to add beneath the bridge to account for filament drooping.</string>
      </property>
     </widget>
    </item>

--- a/Resources/panels/ffDesign_Teardrop.ui
+++ b/Resources/panels/ffDesign_Teardrop.ui
@@ -14,21 +14,21 @@
    <string>Teardrop</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QRadioButton" name="Angle90">
      <property name="text">
       <string>90° Teardrop Angle</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
     <widget class="QRadioButton" name="Angle120">
      <property name="text">
       <string>120° Teardrop Angle</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="0" colspan="2">
     <widget class="QCheckBox" name="DoCounterbore">
     <property name="toolTip">
       <string>Also add a Teardrop shape to the counterbore of this hole.</string>
@@ -38,7 +38,7 @@
     </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="0" colspan="2">
     <widget class="QCheckBox" name="DoubleSided">
     <property name="toolTip">
       <string>Make the Teardrop shape double sided (symmetric).</string>
@@ -46,6 +46,23 @@
     <property name="text">
       <string>Make Teardrop shape double sided</string>
     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Rotation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="Gui::QuantitySpinBox" name="TeardropRotation" native="true">
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+     <property name="toolTip">
+      <string>Direction of the teardrop around the hole axis.</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/Resources/panels/ffDesign_Teardrop.ui
+++ b/Resources/panels/ffDesign_Teardrop.ui
@@ -14,17 +14,17 @@
    <string>Teardrop</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QRadioButton" name="Angle120">
-     <property name="text">
-      <string>120° Teardrop Angle</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QRadioButton" name="Angle90">
      <property name="text">
       <string>90° Teardrop Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="Angle120">
+     <property name="text">
+      <string>120° Teardrop Angle</string>
      </property>
     </widget>
    </item>

--- a/ffDesign_RoofBridge.py
+++ b/ffDesign_RoofBridge.py
@@ -213,6 +213,9 @@ class RoofBridgeTaskPanel:
         # Default is 45° overhang angle
         self.form.Angle45.toggle()
 
+        # 90° means "up" in the sketch plane, usually
+        self.form.BridgeRotation.setProperty("rawValue", 90)
+
     def accept(self):
         try:
             angle = "45 deg"
@@ -224,6 +227,7 @@ class RoofBridgeTaskPanel:
             do_counterbore = self.form.DoCounterbore.checkState() == QtCore.Qt.CheckState.Checked
             do_doublesided = self.form.DoubleSided.checkState() == QtCore.Qt.CheckState.Checked
             bridge_clearance = self.form.BridgeClearance.property("value")
+            bridge_rotation = self.form.BridgeRotation.property("value")
 
             Gui.Control.closeDialog()
 
@@ -233,7 +237,7 @@ class RoofBridgeTaskPanel:
                     self.body,
                     self.hole,
                     angle=angle,
-                    rotation="90 deg",
+                    rotation=bridge_rotation,
                     do_counterbore=do_counterbore,
                     do_doublesided=do_doublesided,
                     bridge_clearance=bridge_clearance,

--- a/ffDesign_Teardrop.py
+++ b/ffDesign_Teardrop.py
@@ -170,6 +170,9 @@ class TeardropTaskPanel:
         # Default is 120° teardrop angle
         self.form.Angle120.toggle()
 
+        # 90° means "up" in the sketch plane, usually
+        self.form.TeardropRotation.setProperty("rawValue", 90)
+
     def accept(self):
         try:
             angle = "120 deg"
@@ -180,6 +183,7 @@ class TeardropTaskPanel:
 
             do_counterbore = self.form.DoCounterbore.checkState() == QtCore.Qt.CheckState.Checked
             double_sided = self.form.DoubleSided.checkState() == QtCore.Qt.CheckState.Checked
+            rotation = self.form.TeardropRotation.property("value")
 
             Gui.Control.closeDialog()
 
@@ -189,7 +193,7 @@ class TeardropTaskPanel:
                     self.body,
                     self.hole,
                     angle=angle,
-                    rotation="90 deg",
+                    rotation=rotation,
                     do_counterbore=do_counterbore,
                     double_sided=double_sided,
                 )

--- a/ffDesign_Teardrop.py
+++ b/ffDesign_Teardrop.py
@@ -45,9 +45,7 @@ def _single_tear(
         Sketcher.Constraint("DistanceX", last_geo_id + 0, 3, 0),
         Sketcher.Constraint("DistanceY", last_geo_id + 0, 3, 0),
         Sketcher.Constraint("Diameter", last_geo_id + 0, 2),
-        Sketcher.Constraint(
-            "Angle", last_geo_id + 1, 2, last_geo_id + 2, 2, math.pi / 2
-        ),
+        Sketcher.Constraint("Angle", last_geo_id + 1, 2, last_geo_id + 2, 2, math.pi / 2),
         Sketcher.Constraint("Angle", last_geo_id + 3, math.pi / 2),
     ]
     sketch.addConstraint(new_constraints)
@@ -71,9 +69,7 @@ def make_parametric_teardrop(
 ):
     Utils.assert_sketch(sketch)
 
-    last_geo_id, last_c = _single_tear(
-        sketch, hole_loc, diameter_expr, angle_expr, rotation_expr
-    )
+    last_geo_id, last_c = _single_tear(sketch, hole_loc, diameter_expr, angle_expr, rotation_expr)
     if double_sided:
         last_geo_id2, last_c2 = _single_tear(
             sketch, hole_loc, diameter_expr, angle_expr, f"({rotation_expr}) + 180 deg"
@@ -106,23 +102,17 @@ def make_teardrops(
     assert rotation.Unit.Type == "Angle"
 
     if "TeardropAngle" not in hole.PropertiesList:
-        hole.addProperty(
-            "App::PropertyAngle", "TeardropAngle", group="FusedFilamentDesign"
-        )
+        hole.addProperty("App::PropertyAngle", "TeardropAngle", group="FusedFilamentDesign")
     hole.TeardropAngle = angle
 
     if "TeardropRotation" not in hole.PropertiesList:
-        hole.addProperty(
-            "App::PropertyAngle", "TeardropRotation", group="FusedFilamentDesign"
-        )
+        hole.addProperty("App::PropertyAngle", "TeardropRotation", group="FusedFilamentDesign")
     hole.TeardropRotation = rotation
 
     profile_sketch = Utils.get_hole_profile_sketch(hole)
     teardrop_sketch = Utils.make_derived_sketch(body, profile_sketch, "_Teardrops")
 
-    hole_locations = Utils.get_sketch_locations(
-        profile_sketch, Utils.get_hole_profile_type(hole)
-    )
+    hole_locations = Utils.get_sketch_locations(profile_sketch, Utils.get_hole_profile_type(hole))
     for hole_loc in hole_locations:
         make_parametric_teardrop(
             teardrop_sketch,
@@ -146,9 +136,7 @@ def make_teardrops(
     if not do_counterbore or not Utils.hole_has_counterbore_maybe(hole):
         return
 
-    teardrops_cb_sketch = Utils.make_derived_sketch(
-        body, profile_sketch, "_TeardropsCb"
-    )
+    teardrops_cb_sketch = Utils.make_derived_sketch(body, profile_sketch, "_TeardropsCb")
 
     for hole_loc in hole_locations:
         make_parametric_teardrop(
@@ -177,9 +165,7 @@ class TeardropTaskPanel:
 
         self.body = body
         self.hole = hole
-        self.form = Gui.PySideUic.loadUi(
-            Utils.Resources.get_panel("ffDesign_Teardrop.ui")
-        )
+        self.form = Gui.PySideUic.loadUi(Utils.Resources.get_panel("ffDesign_Teardrop.ui"))
 
         # Default is 120° teardrop angle
         self.form.Angle120.toggle()
@@ -192,12 +178,8 @@ class TeardropTaskPanel:
             elif self.form.Angle120.isChecked():
                 angle = "120 deg"
 
-            do_counterbore = (
-                self.form.DoCounterbore.checkState() == QtCore.Qt.CheckState.Checked
-            )
-            double_sided = (
-                self.form.DoubleSided.checkState() == QtCore.Qt.CheckState.Checked
-            )
+            do_counterbore = self.form.DoCounterbore.checkState() == QtCore.Qt.CheckState.Checked
+            double_sided = self.form.DoubleSided.checkState() == QtCore.Qt.CheckState.Checked
 
             Gui.Control.closeDialog()
 


### PR DESCRIPTION
See #53. Added the rotation property that is already added to the original `PartDesign_Hole` to the task panels so it is more obviously available.