### PR TITLE
RibThreads: Add workaround for upstream bug with taper angle on two-sided pockets

### DIFF
--- a/ffDesign_RibThreads.py
+++ b/ffDesign_RibThreads.py
@@ -396,14 +396,35 @@ def make_rib_threads(body, hole, global_template: bool, rib_param: RibParameters
     pocket_entrance.Profile = (sketch_entrance, "")
     pocket_entrance.ReferenceAxis = (sketch_entrance, ["N_Axis"])
     pocket_entrance.Reversed = hole.Reversed
-    Utils.set_pocket_two_lengths(pocket_entrance)
-    pocket_entrance.TaperAngle = "-20 deg"
+    pocket_entrance.Label = f"{hole.Label}_ThreadEntrance"
+
     sketch_entrance.Visibility = False
+
+    pocket_entrance.TaperAngle = "-20 deg"
     # 2.8 is roughly the tan(90 - 20 deg), so the taper will be complete
     pocket_entrance.setExpression("Length", f"({varset.Name}.EntranceDiameter - {hole.Name}.Diameter) * 2.8")
-    pocket_entrance.setExpression("Length2", f"{varset.Name}.EntranceDepth")
-    pocket_entrance.Label = f"{hole.Label}_ThreadEntrance"
-    pocket_entrance.recompute()
+
+    if Utils.two_sided_taper_works(pocket_entrance):
+        Utils.set_pocket_two_lengths(pocket_entrance)
+        pocket_entrance.setExpression("Length2", f"{varset.Name}.EntranceDepth")
+        pocket_entrance.recompute()
+    else:
+        pocket_entrance.recompute()
+
+        # if two_sided_taper_works() is False, we build two Pockets, one for each direction...
+
+        Utils.Log.warning("Generating second entrance pocket to work around a bug with two-sided tapered pockets!")
+
+        pocket_entrance2 = body.newObject("PartDesign::Pocket", f"{hole.Name}_ThreadEntrance2")
+        pocket_entrance2.Profile = (sketch_entrance, "")
+        pocket_entrance2.ReferenceAxis = (sketch_entrance, ["N_Axis"])
+        pocket_entrance2.Label = f"{hole.Label}_ThreadEntrance2"
+
+        # This is reversed to the Hole!
+        pocket_entrance2.Reversed = not hole.Reversed
+
+        pocket_entrance2.setExpression("Length", f"{varset.Name}.EntranceDepth")
+        pocket_entrance2.recompute()
 
 
 class RibThreadsTaskPanel:

--- a/ffDesign_Tests.py
+++ b/ffDesign_Tests.py
@@ -140,6 +140,30 @@ class PartialHoleProfiles(ffDesignTestCase_Fc11):
         self.assert_expected_body()
 
 
+class TwoSidedTaperBug(ffDesignTestCase):
+    test_document = "TwoSidedTaperBug.FCStd"
+
+    @unittest.expectedFailure
+    def test_plausibility(self):
+        self.prepare_regression_test()
+        self.assert_expected_body()
+
+    def test_two_sided_taper_bug(self):
+        self.prepare_regression_test()
+
+        # TODO tiPiL2ai: Use the command rather than directly generating using the addon function
+        hole = self.body.Tip
+        Utils.assert_hole(hole)
+
+        ffDesign_RibThreads.verify_rib_thread_suitability(hole)
+
+        dialog = ffDesign_RibThreads.RibThreadsTaskPanel(self.body, hole)
+        Gui.Control.showDialog(dialog)
+        dialog.accept()
+
+        self.assert_expected_body()
+
+
 class RibThreads(ffDesignTestCase):
     test_document = "TapHoles.FCStd"
 
@@ -149,7 +173,7 @@ class RibThreads(ffDesignTestCase):
         """
         self.prepare_regression_test()
 
-        # TODO: Use the command rather than directly generating using the addon function
+        # TODO tiPiL2ai: Use the command rather than directly generating using the addon function
         hole = self.body.Tip
         Utils.assert_hole(hole)
 

--- a/ffDesign_Utils.py
+++ b/ffDesign_Utils.py
@@ -427,6 +427,22 @@ def undo_shapebinder_is_safe() -> bool:
     return check_freecad_version(min_version=[1, 1, 0])
 
 
+def two_sided_taper_works(pocket) -> bool:
+    """
+    In some versions of FreeCAD, taper angles do not work reliably on "Two
+    sided" pockets.
+
+    See https://github.com/FreeCAD/FreeCAD/issues/32262
+    """
+    # TODO: Add another return True once there is a fixed version...
+
+    # It got broken with the change introducing `SideType`
+    if hasattr(pocket, "SideType"):
+        return False
+
+    return True
+
+
 def set_pocket_two_lengths(pocket):
     try:
         # In more recent versions, a two-length pocket is created using `SideType`


### PR DESCRIPTION
FreeCAD 1.1 has a bug where the entrance taper direction depends on the direction of the pocket when a "Two sided" pocket is created (https://github.com/FreeCAD/FreeCAD/issues/32262).

As a workaround, do not generate a "Two sided" pocket on affected FreeCAD versions, but instead generate two separate pockets, one for each direction.

It is implemented using a feature-toggle (`Utils.two_sided_taper_works()`), so we can revert back to the old generation code once this is fixed upstream.

Fixes #58.